### PR TITLE
:lipstick: Fix line number css display

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -476,7 +476,7 @@ class Editor extends React.Component {
                 />)}
             </div>} */}
             <pre
-                className={`language-${language} line-numbers copy-to-clipboard show-language`}
+                className={`language-${language} ${lineNumber ? 'line-numbers ' : ''}copy-to-clipboard show-language`}
                 ref={ref => this.pre = ref}
                 style={{ marginTop: 0 }}
                 dangerouslySetInnerHTML={{ __html: content }}


### PR DESCRIPTION
Hi !

There is a small CSS issue with line numbers.
The class should not be present when setting `lineNumber` property to false.